### PR TITLE
Security fix, HTTP API migration, PHP 8.2 + WP 7.0 compatibility

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -117,7 +117,7 @@ Automatic updates should work great for you.  As always, though, we recommend ba
 * Security - Enables TLS peer verification on PayPal API requests (previously disabled).
 * Tweak - Migrates PayPal API requests from raw cURL to the WordPress HTTP API (`wp_remote_post`).
 * Tweak - Compatibility refresh: requires WordPress 6.2+ and PHP 7.4+; tested up to WordPress 7.0.
-* Fix - PHP 8.2 compatibility: silences dynamic property deprecation notices in the PayPal NVP wrapper class.
+* Fix - PHP 8.2 compatibility: explicitly declares previously-dynamic properties (`NVPCredentials`, `Countries`, `States`, `AVSCodes`, `CVV2Codes`, `CurrencyCodes`) on the PayPal NVP wrapper class to resolve dynamic-property deprecation notices.
 * Fix - Repairs broken translation loading (was passing a URL to `load_plugin_textdomain` and loading `.po` instead of `.mo`); textdomain now loads on `init` for WordPress 6.7+ translation timing rules.
 * Fix - Corrects a malformed `wp_enqueue_style` dependency argument that passed an integer where an array was expected.
 * Fix - Null-guards `get_current_screen()` in admin asset enqueue methods to avoid PHP 8 fatal when called outside a standard admin screen.

--- a/README.txt
+++ b/README.txt
@@ -118,6 +118,9 @@ Automatic updates should work great for you.  As always, though, we recommend ba
 * Tweak - Migrates PayPal API requests from raw cURL to the WordPress HTTP API (`wp_remote_post`).
 * Tweak - Compatibility refresh: requires WordPress 6.2+ and PHP 7.4+; tested up to WordPress 7.0.
 * Fix - PHP 8.2 compatibility: silences dynamic property deprecation notices in the PayPal NVP wrapper class.
+* Fix - Repairs broken translation loading (was passing a URL to `load_plugin_textdomain` and loading `.po` instead of `.mo`); textdomain now loads on `init` for WordPress 6.7+ translation timing rules.
+* Fix - Corrects a malformed `wp_enqueue_style` dependency argument that passed an integer where an array was expected.
+* Fix - Null-guards `get_current_screen()` in admin asset enqueue methods to avoid PHP 8 fatal when called outside a standard admin screen.
 
 = 2.0.2.3 - 12.30.2019 =
 * Tweak - Adjustment to Updater plugin notice dismissible. ([PBM-38](https://github.com/angelleye/paypal-wp-button-manager/pull/120))

--- a/README.txt
+++ b/README.txt
@@ -2,9 +2,10 @@
 Contributors: angelleye
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=SG9SQU2GBXJNA
 Tags: paypal, payments, standard, subscriptions, buy now, shopping cart, gift certificates
-Requires at least: 3.8
-Tested up to: 5.3.2
-Stable tag: 2.0.2.3
+Requires at least: 6.2
+Tested up to: 7.0
+Requires PHP: 7.4
+Stable tag: 2.0.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -111,6 +112,12 @@ Automatic updates should work great for you.  As always, though, we recommend ba
 * Sandbox credentials can be obtained by viewing the sandbox account profile within your PayPal developer account, or by signing in with a sandbox account here:  https://www.sandbox.paypal.com/us/cgi-bin/webscr?cmd=_get-api-signature&generic-flow=true
 
 == Changelog ==
+
+= 2.0.3 - 05.25.2026 =
+* Security - Enables TLS peer verification on PayPal API requests (previously disabled).
+* Tweak - Migrates PayPal API requests from raw cURL to the WordPress HTTP API (`wp_remote_post`).
+* Tweak - Compatibility refresh: requires WordPress 6.2+ and PHP 7.4+; tested up to WordPress 7.0.
+* Fix - PHP 8.2 compatibility: silences dynamic property deprecation notices in the PayPal NVP wrapper class.
 
 = 2.0.2.3 - 12.30.2019 =
 * Tweak - Adjustment to Updater plugin notice dismissible. ([PBM-38](https://github.com/angelleye/paypal-wp-button-manager/pull/120))

--- a/admin/class-paypal-wp-button-manager-admin.php
+++ b/admin/class-paypal-wp-button-manager-admin.php
@@ -49,8 +49,8 @@ class AngellEYE_PayPal_WP_Button_Manager_Admin {
      * @since    0.1.0
      */
 	public function enqueue_styles() {
-                $screen = get_current_screen();
-		if($screen->post_type == 'paypal_buttons' && $screen->id == 'paypal_buttons'){
+		$screen = get_current_screen();
+		if ( $screen && $screen->post_type == 'paypal_buttons' && $screen->id == 'paypal_buttons' ) {
 			wp_enqueue_style($this->plugin_name . 'eight', plugin_dir_url(__FILE__) . 'css/bootstrap/css/bootstrap.css', array(), $this->version, 'all');
 		}
 		wp_enqueue_style('thickbox'); // call to media files in wp
@@ -59,7 +59,7 @@ class AngellEYE_PayPal_WP_Button_Manager_Admin {
 		wp_enqueue_style($this->plugin_name . 'two', plugin_dir_url(__FILE__) . '/css/paypal-wp-button-manager-coreLayout.css', array(), $this->version, false);
 		wp_enqueue_style($this->plugin_name . 'three', plugin_dir_url(__FILE__) . '/css/paypal-wp-button-manager-me2.css', array(), $this->version, false);
 		wp_enqueue_style($this->plugin_name . 'four', plugin_dir_url(__FILE__) . '/css/paypal-wp-button-manager-print.css', array(), $this->version, false);
-		wp_enqueue_style($this->plugin_name . 'five', plugin_dir_url(__FILE__) . 'css/paypal-wp-button-manager-admin.css', 20, $this->version, 'all');
+		wp_enqueue_style($this->plugin_name . 'five', plugin_dir_url(__FILE__) . 'css/paypal-wp-button-manager-admin.css', array(), $this->version, 'all');
 		wp_enqueue_style($this->plugin_name . 'seven', plugin_dir_url(__FILE__) . 'css/webkit/fontello.css', array(), $this->version, 'all');
 
 	}
@@ -84,11 +84,11 @@ class AngellEYE_PayPal_WP_Button_Manager_Admin {
 		wp_enqueue_script($this->plugin_name . 'three', plugin_dir_url(__FILE__) . 'js/paypal-wp-button-manager-pa.js', array('jquery'), $this->version, false);
 		wp_enqueue_script($this->plugin_name . 'five', plugin_dir_url(__FILE__) . 'js/paypal-wp-button-manager-widgets.js', array('jquery'), $this->version, false);		
 
-                if($screen->post_type == 'paypal_buttons'){
+                if ( $screen && $screen->post_type == 'paypal_buttons' ) {
                     wp_enqueue_script($this->plugin_name . 'six', plugin_dir_url(__FILE__) . 'css/bootstrap/js/bootstrap.min.js', array('jquery'), $this->version, false);
                 }
-                
-		if($screen->post_type == 'paypal_buttons')
+
+		if ( $screen && $screen->post_type == 'paypal_buttons' )
 		{
 			wp_enqueue_script($this->plugin_name . 'admin-image-uploader', plugin_dir_url(__FILE__) . 'js/paypal-wp-button-manager-admin-image-uploader.js', array('jquery'), $this->version, false);
 		}

--- a/admin/partials/Angelleye_PayPal.php
+++ b/admin/partials/Angelleye_PayPal.php
@@ -38,6 +38,7 @@
  * @package 		paypal-php-library
  * @author			Andrew Angell <service@angelleye.com>
  */
+#[\AllowDynamicProperties]
 class Angelleye_PayPal {
 
     var $APIUsername = '';
@@ -583,42 +584,47 @@ class Angelleye_PayPal {
     }
 
     /**
-     * Send the API request to PayPal using CURL.
+     * Send the API request to PayPal via the WordPress HTTP API.
      *
      * @access	public
      * @param	string	$Request		Raw API request string.
      * @param	string	$APIName		The name of the API which you are calling.
      * @param	string	$APIOperation	The method of the API which you are calling.
      * @param   string  $PrintHeaders   The option to print headers or not.
-     * @return	string	$Response		Returns the raw HTTP response from PayPal.
+     * @return	string	$Response		Returns the raw HTTP response body from PayPal.
      */
     function CURLRequest($Request = "", $APIName = "", $APIOperation = "", $PrintHeaders = false) {
-        $curl = curl_init();
-        // curl_setopt($curl, CURLOPT_HEADER,TRUE);
-        curl_setopt($curl, CURLOPT_VERBOSE, 1);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
-        curl_setopt($curl, CURLOPT_TIMEOUT, 30);
-        curl_setopt($curl, CURLOPT_URL, $this->EndPointURL);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($curl, CURLOPT_POSTFIELDS, $Request);
-
-        if ($this->APIMode == 'Certificate') {
-            curl_setopt($curl, CURLOPT_SSLCERT, $this->PathToCertKeyPEM);
+        $cert_filter = null;
+        if ($this->APIMode == 'Certificate' && !empty($this->PathToCertKeyPEM)) {
+            $cert_path = $this->PathToCertKeyPEM;
+            $cert_filter = function ($handle) use ($cert_path) {
+                curl_setopt($handle, CURLOPT_SSLCERT, $cert_path);
+            };
+            add_action('http_api_curl', $cert_filter, 10, 1);
         }
 
-        $Response = curl_exec($curl);
+        $response = wp_remote_post($this->EndPointURL, array(
+            'timeout'     => 30,
+            'redirection' => 0,
+            'sslverify'   => true,
+            'body'        => $Request,
+            'headers'     => array(
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ),
+        ));
 
-        /*
-         * If a cURL error occurs, output it for review.
-         */
-        if ($this->Sandbox) {
-            if (curl_error($curl)) {
-                echo curl_error($curl) . '<br /><br />';
+        if ($cert_filter !== null) {
+            remove_action('http_api_curl', $cert_filter, 10);
+        }
+
+        if (is_wp_error($response)) {
+            if ($this->Sandbox) {
+                echo esc_html($response->get_error_message()) . '<br /><br />';
             }
+            return '';
         }
 
-        curl_close($curl);
-        return $Response;
+        return wp_remote_retrieve_body($response);
     }
 
     /**

--- a/admin/partials/Angelleye_PayPal.php
+++ b/admin/partials/Angelleye_PayPal.php
@@ -38,7 +38,6 @@
  * @package 		paypal-php-library
  * @author			Andrew Angell <service@angelleye.com>
  */
-#[\AllowDynamicProperties]
 class Angelleye_PayPal {
 
     var $APIUsername = '';
@@ -55,6 +54,12 @@ class Angelleye_PayPal {
     var $PrintHeaders = '';
     var $LogResults = '';
     var $LogPath = '';
+    var $NVPCredentials = '';
+    var $Countries = array();
+    var $States = array();
+    var $AVSCodes = array();
+    var $CVV2Codes = array();
+    var $CurrencyCodes = array();
 
     /**
      * Constructor

--- a/includes/class-paypal-wp-button-manager-i18n.php
+++ b/includes/class-paypal-wp-button-manager-i18n.php
@@ -28,14 +28,11 @@ class AngellEYE_PayPal_WP_Button_Manager_i18n {
      * @since    0.1.0
      */
     public function load_plugin_textdomain() {
-		$locale = apply_filters( 'plugin_locale', get_locale(), $this->domain );
-       /* load_plugin_textdomain(
-                $this->domain, false, dirname(dirname(plugin_basename(__FILE__))) . '/languages/'
-        );*/
-        
-       
-		load_textdomain( $this->domain, BMW_PLUGIN_URL . 'languages/' . $this->domain . '-' . $locale . '.po' );
-		load_plugin_textdomain( $this->domain, FALSE, BMW_PLUGIN_URL . '/languages/' );
+        load_plugin_textdomain(
+            $this->domain,
+            false,
+            dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
+        );
     }
 
     /**

--- a/includes/class-paypal-wp-button-manager.php
+++ b/includes/class-paypal-wp-button-manager.php
@@ -198,7 +198,7 @@ class AngellEYE_PayPal_WP_Button_Manager {
         $plugin_i18n = new AngellEYE_PayPal_WP_Button_Manager_i18n();
         $plugin_i18n->set_domain($this->get_plugin_name());
 
-        $this->loader->add_action('plugins_loaded', $plugin_i18n, 'load_plugin_textdomain');
+        $this->loader->add_action('init', $plugin_i18n, 'load_plugin_textdomain');
     }
 
     /**

--- a/includes/class-paypal-wp-button-manager.php
+++ b/includes/class-paypal-wp-button-manager.php
@@ -56,7 +56,7 @@ class AngellEYE_PayPal_WP_Button_Manager {
     public function __construct() {
 
         $this->plugin_name = 'paypal-wp-button-manager';
-        $this->version = '2.0.2.3';
+        $this->version = '2.0.3';
 
         $this->load_dependencies();
         $this->set_locale();

--- a/paypal-wp-button-manager.php
+++ b/paypal-wp-button-manager.php
@@ -5,13 +5,16 @@
  * Plugin Name:       PayPal WP Button Manager
  * Plugin URI:        http://www.angelleye.com/
  * Description:       Easily create and manage secure PayPal buttons for WordPress
- * Version:           2.0.2.3
+ * Version:           2.0.3
  * Author:            Angell EYE
  * Author URI:        http://www.angelleye.com/
  * License:           GNU General Public License v3.0
  * License URI:       http://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:       paypal-wp-button-manager
  * Domain Path:       /languages
+ * Requires at least: 6.2
+ * Tested up to:      7.0
+ * Requires PHP:      7.4
  */
 // If this file is called directly, abort.
 if (!defined('WPINC')) {


### PR DESCRIPTION
## Summary

First maintenance release since 2019 (2.0.2.3, Dec 2019). Brings the plugin onto current PHP/WordPress, replaces an insecure cURL call, repairs broken translation loading, and fixes a handful of latent bugs that would have surfaced under PHP 8.x.

**Intentionally out of scope:** migrating off PayPal's deprecated NVP/Button Manager API, replacing bundled Bootstrap 3, modernizing Gutenberg blocks to `block.json`, and GDPR/privacy hooks. Those belong to a follow-up 2.1.0 milestone.

## Changes

### Security

- **Enable TLS peer verification on PayPal API requests.** [`admin/partials/Angelleye_PayPal.php`](admin/partials/Angelleye_PayPal.php) — `CURLOPT_SSL_VERIFYPEER` was hard-coded to `FALSE`, exposing API calls (including credentials) to MITM. Now defaults to `true` via the WP HTTP API.

### HTTP layer

- **Migrate `Angelleye_PayPal::CURLRequest` from raw cURL to `wp_remote_post`.** [`admin/partials/Angelleye_PayPal.php`](admin/partials/Angelleye_PayPal.php) — requests now honor site-wide HTTP filters, proxies, and core TLS handling. Certificate auth mode preserved via a scoped `http_api_curl` action that adds/removes `CURLOPT_SSLCERT` only for the request that needs it.

### PHP 8.2 compatibility

- **Explicitly declare previously-dynamic properties on `Angelleye_PayPal`.** Added: `NVPCredentials`, `Countries`, `States`, `AVSCodes`, `CVV2Codes`, `CurrencyCodes`. Resolves the PHP 8.2 dynamic-property deprecation properly (no `#[\AllowDynamicProperties]` shim).
- **Null-guard `get_current_screen()`** in admin enqueue methods. [`admin/class-paypal-wp-button-manager-admin.php`](admin/class-paypal-wp-button-manager-admin.php) — accessing `$screen->post_type` without a null check would fatal on PHP 8 when called outside a standard admin screen.

### Internationalization

- **Repair broken translation loading.** [`includes/class-paypal-wp-button-manager-i18n.php`](includes/class-paypal-wp-button-manager-i18n.php) — `load_plugin_textdomain()` was being passed a URL (`BMW_PLUGIN_URL`) instead of a relative path, and `load_textdomain()` was pointed at a `.po` file (it requires `.mo`). Translations have never actually loaded. Now uses a proper relative path via `dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'`.
- **Move textdomain hook from `plugins_loaded` to `init`.** [`includes/class-paypal-wp-button-manager.php:201`](includes/class-paypal-wp-button-manager.php#L201) — aligns with WordPress 6.7+ strict translation-loading timing rules.

### Bug fixes

- **Fix malformed `wp_enqueue_style` call.** [`admin/class-paypal-wp-button-manager-admin.php:62`](admin/class-paypal-wp-button-manager-admin.php#L62) — third argument was `20` (an int) where an array of dependencies is required.

### Compatibility metadata

- Plugin header & `README.txt`:
  - `Requires at least: 6.2`
  - `Tested up to: 7.0`
  - `Requires PHP: 7.4`
  - `Stable tag: 2.0.3`
- Bumped `Version:` to `2.0.3` in plugin header and internal `$this->version` constant.
- Added a 2.0.3 changelog entry.

## Files changed

- `paypal-wp-button-manager.php` — headers, version
- `README.txt` — headers, stable tag, changelog
- `includes/class-paypal-wp-button-manager.php` — internal version constant, i18n hook moved to `init`
- `includes/class-paypal-wp-button-manager-i18n.php` — rewrote `load_plugin_textdomain` to use a real relative path
- `admin/partials/Angelleye_PayPal.php` — TLS verification, wp_remote_post migration, explicit property declarations
- `admin/class-paypal-wp-button-manager-admin.php` — `$deps` arg fix, `get_current_screen()` null guards

## Test plan

- [ ] `php -l` clean on all edited files (verified locally)
- [ ] Fresh install activates cleanly on:
  - [ ] WordPress 6.2 + PHP 7.4
  - [ ] WordPress 6.7 + PHP 8.1
  - [ ] WordPress 7.0 + PHP 8.2
- [ ] With sandbox NVP credentials, create one of each: Buy Now, Donation, Subscription, Cart button
- [ ] Confirm `debug.log` is clean throughout (no notices/warnings) with `WP_DEBUG=true` and `WP_DEBUG_LOG=true`
- [ ] Confirm PayPal API request goes out over TLS with peer verification on (proxy capture or temporarily logged `wp_remote_post` args)
- [ ] Confirm a `.mo` placed in `wp-content/languages/plugins/` is actually loaded (translations were silently broken before this release)
- [ ] Visit a non-`paypal_buttons` admin screen and confirm no PHP errors fire from the enqueue methods
- [ ] Verify the `updates.angelleye.com` AE Updater endpoint is still reachable before tagging the release

## Follow-up issues (not in this PR)

- Replace bundled Bootstrap 3 (loaded globally on the buttons screen)
- Migrate Gutenberg blocks to `block.json` / `register_block_type()`
- Add `wp_add_privacy_policy_content` + personal-data exporter/eraser hooks
- Encrypt API credentials at rest in `wp_paypal_wp_button_manager_companies`
- Audit AJAX endpoints (`checkconfig`, `delete_paypal_button`, `checkhosted_button`) for nonce/capability coverage
- Larger effort: migrate off deprecated NVP/Express Checkout onto PayPal REST + JS SDK
