### PR TITLE
fix: pass file resource directly to fclose() in logger destructor

### DIFF
--- a/includes/class-paypal-wp-button-manager-logger.php
+++ b/includes/class-paypal-wp-button-manager-logger.php
@@ -35,7 +35,9 @@ class AngellEYE_PayPal_WP_Button_Manager_Logger {
      */
     public function __destruct() {
         foreach ($this->_handles as $handle) {
-            @fclose(escapeshellarg($handle));
+            if (is_resource($handle)) {
+                @fclose($handle);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a fatal `TypeError` thrown when creating a new button in the PayPal WP Button Manager plugin.

## Problem

When saving a new button, the logger's `__destruct()` method passed the open file resource to `escapeshellarg()` before closing it:

```php
@fclose(escapeshellarg($handle));
$handle is a file resource returned by fopen(), not a string. Under PHP 8, escapeshellarg() no longer silently coerces a resource and throws:

Fatal error: Uncaught TypeError: escapeshellarg(): Argument #1 ($arg) must be of type string, resource given in class-paypal-wp-button-manager-logger.php:38
```

## Fix
Pass the resource directly to fclose(), guarded by is_resource() so a failed or already-closed handle won't throw:

```php
foreach ($this->_handles as $handle) {
    if (is_resource($handle)) {
        @fclose($handle);
    }
}
```

## Testing
Creating a new button no longer triggers the fatal error.

## Files Changed
includes/class-paypal-wp-button-manager-logger.php